### PR TITLE
feat: add changed flag for local changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Generate incremental package manifest and source content
 
 ```
 USAGE
-  $ sf sgd source delta -f <value> [--json] [--flags-dir <value>] [-t <value>] [-d] [-o <value>] [-r <value>] [-s
+  $ sf sgd source delta -f <value> [--json] [--flags-dir <value>] [-c] [-t <value>] [-d] [-o <value>] [-r <value>] [-s
     <value>] [-i <value>] [-D <value>] [-n <value>] [-N <value>] [-W] [-a <value>]
 
 FLAGS
@@ -156,6 +156,7 @@ FLAGS
   -W, --ignore-whitespace                 ignore git diff whitespace (space, tab, eol) changes
   -a, --api-version=<value>               salesforce metadata API version, default to sfdx-project.json
                                           "sourceApiVersion" attribute or latest version
+  -c, --changed                           use changed local files instead of commit diff
   -d, --generate-delta                    generate delta files in [--output-dir] folder
   -f, --from=<value>                      (required) commit sha from where the diff is done
   -i, --ignore-file=<value>               file listing paths to explicitly ignore for any diff actions
@@ -164,13 +165,6 @@ FLAGS
   -r, --repo-dir=<value>                  [default: ./] git repository location
   -s, --source-dir=<value>                [default: ./] source folder focus location related to --repo-dir
   -t, --to=<value>                        [default: HEAD] commit sha to where the diff is done
-      --ignore=<value>                    /!\ deprecated, use '--ignore-file' instead.
-      --ignore-destructive=<value>        /!\ deprecated, use '--ignore-destructive-file' instead.
-      --include=<value>                   /!\ deprecated, use '--include-file' instead.
-      --include-destructive=<value>       /!\ deprecated, use '--include-destructive-file' instead.
-      --output=<value>                    /!\ deprecated, use '--output-dir' instead.
-      --repo=<value>                      /!\ deprecated, use '--repo-dir' instead.
-      --source=<value>                    /!\ deprecated, use '--source-dir' instead.
 
 GLOBAL FLAGS
   --flags-dir=<value>  Import flag values from a directory.
@@ -195,7 +189,7 @@ FLAG DESCRIPTIONS
     Override the api version used for api requests made by this command
 ```
 
-_See code: [src/commands/sgd/source/delta.ts](https://github.com/scolladon/sfdx-git-delta/blob/main/src/commands/sgd/source/delta.ts)_
+_See code: [src/commands/sgd/source/delta.ts](https://github.com/scolladon/sfdx-git-delta/blob/v6.6.0/src/commands/sgd/source/delta.ts)_
 <!-- commandsstop -->
 
 ### Windows users

--- a/__tests__/__utils__/globalTestHelper.ts
+++ b/__tests__/__utils__/globalTestHelper.ts
@@ -21,6 +21,7 @@ export const getWork = (): Work => ({
     source: './',
     output: 'output',
     generateDelta: true,
+    changed: false,
     to: '',
     from: '',
     ignore: '',

--- a/__tests__/integration/services.test.ts
+++ b/__tests__/integration/services.test.ts
@@ -480,6 +480,7 @@ beforeEach(() => {
       source: '',
       repo: '',
       generateDelta: true,
+      changed: false,
       to: '',
       from: '',
       ignore: '',

--- a/__tests__/unit/lib/utils/fxpHelper.test.ts
+++ b/__tests__/unit/lib/utils/fxpHelper.test.ts
@@ -16,6 +16,7 @@ jest.mock('../../../../src/utils/fsHelper')
 describe('fxpHelper', () => {
   describe('parseXmlFileToJson', () => {
     const config: Config = {
+      changed: false,
       from: '',
       to: '',
       output: '',

--- a/__tests__/unit/lib/utils/ignoreHelper.test.ts
+++ b/__tests__/unit/lib/utils/ignoreHelper.test.ts
@@ -21,6 +21,7 @@ const mockedReadFile = jest.mocked(readFile)
 describe('ignoreHelper', () => {
   let sut: IgnoreHelper
   const config: Config = {
+    changed: false,
     to: '',
     from: '',
     output: '',

--- a/__tests__/unit/lib/utils/packageHelper.test.ts
+++ b/__tests__/unit/lib/utils/packageHelper.test.ts
@@ -9,6 +9,7 @@ import PackageBuilder, {
 
 const config: Config = {
   apiVersion: 46,
+  changed: false,
   to: '',
   from: '',
   output: '',

--- a/__tests__/unit/lib/utils/repoGitDiff.test.ts
+++ b/__tests__/unit/lib/utils/repoGitDiff.test.ts
@@ -41,6 +41,7 @@ describe(`test if repoGitDiff`, () => {
 
   beforeEach(() => {
     config = {
+      changed: false,
       to: '',
       from: '',
       output: '',

--- a/messages/delta.md
+++ b/messages/delta.md
@@ -24,6 +24,10 @@ commit sha to where the diff is done
 
 commit sha from where the diff is done
 
+# flags.changed.summary
+
+use changed local files instead of commit diff
+
 # flags.repo.summary
 
 git repository location

--- a/src/adapter/GitAdapter.ts
+++ b/src/adapter/GitAdapter.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path/posix'
 
-import { SimpleGit, simpleGit } from 'simple-git'
+import { SimpleGit, StatusResult, simpleGit } from 'simple-git'
 
 import { TAB } from '../constant/cliConstants.js'
 import { PATH_SEP, UTF8_ENCODING } from '../constant/fsConstants.js'
@@ -159,6 +159,61 @@ export default class GitAdapter {
   }
 
   public async getDiffLines(): Promise<string[]> {
+    let lines: string[]
+    if (this.config.changed) {
+      lines = await this.getChangedFiles()
+    } else {
+      lines = await this.getDiffBetweenRefs()
+    }
+    return lines.map(treatPathSep)
+  }
+
+  protected async getChangedFiles(): Promise<string[]> {
+    const status: StatusResult = await this.simpleGit.status()
+    const lines = new Set<string>()
+
+    const mapStatusToChangeType = (filePath: string, statusChar: string) => {
+      let changeType: string | undefined
+      switch (statusChar) {
+        case 'A':
+        case '?':
+          changeType = ADDITION
+          break
+        case 'M':
+        case 'U':
+          changeType = MODIFICATION
+          break
+        case 'D':
+          changeType = DELETION
+          break
+      }
+      if (changeType) {
+        lines.add(`${changeType}${TAB}${filePath}`)
+      }
+    }
+
+    for (const file of status.files) {
+      mapStatusToChangeType(file.path, file.index)
+      mapStatusToChangeType(file.path, file.working_dir)
+    }
+
+    for (const rename of status.renamed) {
+      lines.add(`${ADDITION}${TAB}${rename.to}`)
+    }
+
+    const sourcePrefix = this.config.source.endsWith(PATH_SEP)
+      ? this.config.source
+      : `${this.config.source}${PATH_SEP}`
+
+    return Array.from(lines).filter(
+      line =>
+        line
+          .split(TAB)[1]
+          ?.startsWith(this.config.source === './' ? '' : sourcePrefix) ?? false
+    )
+  }
+
+  protected async getDiffBetweenRefs(): Promise<string[]> {
     let lines: string[] = []
     for (const changeType of [ADDITION, MODIFICATION, DELETION]) {
       const linesOfType = await this.getDiffForType(changeType)
@@ -168,7 +223,7 @@ export default class GitAdapter {
         )
       )
     }
-    return lines.map(treatPathSep)
+    return lines
   }
 
   protected async getDiffForType(changeType: string): Promise<string[]> {

--- a/src/commands/sgd/source/delta.ts
+++ b/src/commands/sgd/source/delta.ts
@@ -20,6 +20,10 @@ export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
   public static override readonly examples = messages.getMessages('examples')
 
   public static override readonly flags = {
+    changed: Flags.boolean({
+      char: 'c',
+      summary: messages.getMessage('flags.changed.summary'),
+    }),
     from: Flags.string({
       char: 'f',
       summary: messages.getMessage('flags.from.summary'),
@@ -101,7 +105,8 @@ export default class SourceDeltaGenerate extends SfCommand<SgdResult> {
 
     const config: Config = {
       apiVersion: parseInt(flags['api-version']!) || undefined,
-      from: flags['from'],
+      changed: flags.changed,
+      from: flags.from,
       generateDelta: flags['generate-delta'],
       ignore: flags['ignore-file'],
       ignoreDestructive: flags['ignore-destructive-file'],

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,4 +1,5 @@
 export type Config = {
+  changed: boolean
   to: string
   from: string
   output: string


### PR DESCRIPTION

# Explain your changes
---

  This change allow to create delta package from the changed local files instead of using commit diffs. I made this feature because I would like to use this plugin in my neovim sf plugin to deploy only modified metadata.


# Does this close any currently open issues?
No

---

<!--
  Provide an issue link or remove this section
  Ex: #<issue-number>
-->

- [x] Jest tests added to cover the fix.
- [x] NUT tests added to cover the fix.
- [x] E2E tests added to cover the fix.

# Any particular element that can be tested locally

---
Changed files can be tested locally.
<!--
  Provide any new parameters or new behaviour with existing parameters
-->
Use -c flag.

# Any other comments
No
---

<!--
  Provide any information you want to share with us
  Dependencies
  Target Release
  ...
-->
